### PR TITLE
8, 11: Ariadne's Moss Improvements

### DIFF
--- a/Ariadne's Moss/data/ariadnes_moss/function/is_near_replaceable.mcfunction
+++ b/Ariadne's Moss/data/ariadnes_moss/function/is_near_replaceable.mcfunction
@@ -1,0 +1,4 @@
+execute if block ~ ~-1 ~ #ariadnes_moss:replaceable at @s run return 1
+execute if block ~ ~ ~ #ariadnes_moss:replaceable at @s run return 1
+
+return fail

--- a/Ariadne's Moss/data/ariadnes_moss/function/place_ariadnes_moss.mcfunction
+++ b/Ariadne's Moss/data/ariadnes_moss/function/place_ariadnes_moss.mcfunction
@@ -1,15 +1,9 @@
-# Player pays moss fee. Higher the level, greater chance of skipping payment
-# Level I
-execute as @s[nbt={Inventory:[{Slot:100b, components:{"minecraft:enchantments":{levels:{"ariadnes_moss:ariadnes_moss":1}}}}]}] run execute if block ~ ~-1 ~ #ariadnes_moss:replaceable at @s run clear @s #ariadnes_moss:moss_payment 1
+# Check if near replaeable. If not, end function
+execute as @s at @s unless function ariadnes_moss:is_near_replaceable run return fail
 
-# Level II
-execute if predicate ariadnes_moss:chance/66_percent as @s[nbt={Inventory:[{Slot:100b, components:{"minecraft:enchantments":{levels:{"ariadnes_moss:ariadnes_moss":2}}}}]}] run execute if block ~ ~-1 ~ #ariadnes_moss:replaceable at @s run clear @s #ariadnes_moss:moss_payment 1
+# Place moss near player
+execute as @s at @s run fill ~0.3 ~0.5 ~0.3 ~-0.3 ~-1.5 ~-0.3 moss_block replace #ariadnes_moss:block_replaceable
+execute as @s at @s run fill ~0.3 ~1.5 ~0.3 ~-0.3 ~-0.5 ~-0.3 moss_carpet replace #ariadnes_moss:carpet_replaceable[down=true]
 
-# Level III
-execute if predicate ariadnes_moss:chance/33_percent as @s[nbt={Inventory:[{Slot:100b, components:{"minecraft:enchantments":{levels:{"ariadnes_moss:ariadnes_moss":3}}}}]}] run execute if block ~ ~-1 ~ #ariadnes_moss:replaceable at @s run clear @s #ariadnes_moss:moss_payment 1
-
-# Level IV
-execute if predicate ariadnes_moss:chance/6.66_percent as @s[nbt={Inventory:[{Slot:100b, components:{"minecraft:enchantments":{levels:{"ariadnes_moss:ariadnes_moss":4}}}}]}] run execute if block ~ ~-1 ~ #ariadnes_moss:replaceable at @s run clear @s #ariadnes_moss:moss_payment 1
-
-# Place moss below player
-execute as @s at @s run execute if block ~ ~-1 ~ #ariadnes_moss:replaceable at @s run setblock ~ ~-1 ~ moss_block
+# Player pays moss fee. Higher the level, greater chance of skipping payment (All logic in predicate)
+execute as @s[predicate=ariadnes_moss:pay_moss] run clear @s #ariadnes_moss:moss_payment 1

--- a/Ariadne's Moss/data/ariadnes_moss/predicate/chance/33_percent.json
+++ b/Ariadne's Moss/data/ariadnes_moss/predicate/chance/33_percent.json
@@ -1,4 +1,0 @@
-{
-  "condition": "minecraft:random_chance",
-  "chance": 0.33
-}

--- a/Ariadne's Moss/data/ariadnes_moss/predicate/chance/6.66_percent.json
+++ b/Ariadne's Moss/data/ariadnes_moss/predicate/chance/6.66_percent.json
@@ -1,4 +1,0 @@
-{
-  "condition": "minecraft:random_chance",
-  "chance": 0.0666
-}

--- a/Ariadne's Moss/data/ariadnes_moss/predicate/chance/66_percent.json
+++ b/Ariadne's Moss/data/ariadnes_moss/predicate/chance/66_percent.json
@@ -1,4 +1,0 @@
-{
-  "condition": "minecraft:random_chance",
-  "chance": 0.66
-}

--- a/Ariadne's Moss/data/ariadnes_moss/predicate/pay_moss.json
+++ b/Ariadne's Moss/data/ariadnes_moss/predicate/pay_moss.json
@@ -1,0 +1,113 @@
+{
+  "condition": "minecraft:any_of",
+  "terms": [
+    {
+      "condition": "minecraft:all_of",
+      "terms": [
+        {
+          "condition": "minecraft:entity_properties",
+          "entity": "this",
+          "predicate": {
+            "equipment": {
+              "feet": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "ariadnes_moss:ariadnes_moss",
+                      "levels": 1
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "condition": "minecraft:random_chance",
+          "chance": 1
+        }
+      ]
+    },
+    {
+      "condition": "minecraft:all_of",
+      "terms": [
+        {
+          "condition": "minecraft:entity_properties",
+          "entity": "this",
+          "predicate": {
+            "equipment": {
+              "feet": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "ariadnes_moss:ariadnes_moss",
+                      "levels": 2
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "condition": "minecraft:random_chance",
+          "chance": 0.66
+        }
+      ]
+    },
+    {
+      "condition": "minecraft:all_of",
+      "terms": [
+        {
+          "condition": "minecraft:entity_properties",
+          "entity": "this",
+          "predicate": {
+            "equipment": {
+              "feet": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "ariadnes_moss:ariadnes_moss",
+                      "levels": 3
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "condition": "minecraft:random_chance",
+          "chance": 0.33
+        }
+      ]
+    },
+    {
+      "condition": "minecraft:all_of",
+      "terms": [
+        {
+          "condition": "minecraft:entity_properties",
+          "entity": "this",
+          "predicate": {
+            "equipment": {
+              "feet": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "ariadnes_moss:ariadnes_moss",
+                      "levels": 4
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "condition": "minecraft:random_chance",
+          "chance": 0.066
+        }
+      ]
+    }
+  ]
+}

--- a/Ariadne's Moss/data/ariadnes_moss/tags/block/block_replaceable.json
+++ b/Ariadne's Moss/data/ariadnes_moss/tags/block/block_replaceable.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:sculk"
+  ]
+}

--- a/Ariadne's Moss/data/ariadnes_moss/tags/block/carpet_replaceable.json
+++ b/Ariadne's Moss/data/ariadnes_moss/tags/block/carpet_replaceable.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:sculk_vein"
+  ]
+}

--- a/Ariadne's Moss/data/ariadnes_moss/tags/block/replaceable.json
+++ b/Ariadne's Moss/data/ariadnes_moss/tags/block/replaceable.json
@@ -1,5 +1,6 @@
 {
   "values": [
-    "minecraft:sculk"
+    "#ariadnes_moss:block_replaceable",
+    "#ariadnes_moss:carpet_replaceable"
   ]
 }

--- a/Ariadne's Moss/data/minecraft/loot_table/gameplay/sniffer_digging.json
+++ b/Ariadne's Moss/data/minecraft/loot_table/gameplay/sniffer_digging.json
@@ -16,7 +16,7 @@
         },
         {
           "type": "minecraft:loot_table",
-          "value": "adriadnes_moss:sniffer_adriadnes_moss",
+          "value": "ariadnes_moss:sniffer_ariadnes_moss",
           "weight": 26
         }
       ],


### PR DESCRIPTION
- Moss now replaces in an area just bigger than 1 block to feel better on corners and ledges (#11)
- Sculk Veins can now be replaced by moss carpet (determined by the #carpet_replaceable tag, but limited to blocks with a down property... So just glow lichen) (#8)
- Moved payment logic to a single predicate (so clean!)
- Cleanup/Refactoring